### PR TITLE
Mix categories in the TreeMap view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,7 +46,7 @@ class App extends Component {
       categories: [],
       selectedCategories: availableCategories,
       selectedEditions: ["uk"],
-      mode: "tree_mixed",
+      mode: "tree",
       showImages: false,
       palette: "default",
       showOptions: false,
@@ -220,9 +220,9 @@ class App extends Component {
                 View Mode
               </label>
               <select value={mode} onChange={e => this.setSavedState({ mode: e.target.value })}>
-                <option value="tree_mixed">Tree Map mixed</option>
-                <option value="tree">Tree Map per Category</option>
-                <option value="grid">Grid per Category</option>
+                <option value="tree">Tree Map</option>
+                <option value="tree_mixed">Tree Map (mixed)</option>
+                <option value="grid">Grid</option>
               </select>
             </div>
             <div className="App-formgroup">

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ import './App.css';
  * @prop {Category[]} categories
  * @prop {string[]} selectedCategories
  * @prop {string[]} selectedEditions
- * @prop {"tree"|"grid"} mode
+ * @prop {"tree"|"grid"|"tree_mixed"} mode
  * @prop {boolean} showImages
  * @prop {boolean} showOptions
  * @prop {boolean} headerTop
@@ -46,7 +46,7 @@ class App extends Component {
       categories: [],
       selectedCategories: availableCategories,
       selectedEditions: ["uk"],
-      mode: "tree",
+      mode: "tree_mixed",
       showImages: false,
       palette: "default",
       showOptions: false,
@@ -220,8 +220,9 @@ class App extends Component {
                 View Mode
               </label>
               <select value={mode} onChange={e => this.setSavedState({ mode: e.target.value })}>
-                <option value="tree">Tree Map</option>
-                <option value="grid">Grid</option>
+                <option value="tree_mixed">Tree Map mixed</option>
+                <option value="tree">Tree Map per Category</option>
+                <option value="grid">Grid per Category</option>
               </select>
             </div>
             <div className="App-formgroup">

--- a/src/Article.js
+++ b/src/Article.js
@@ -20,7 +20,7 @@ export default function Article ({ item, category, showImage, colours = defaultC
     style.backgroundImage = `url(${item.imageURL})`;
   }
 
-  const backgroundColor = getAgedColour(colours[category.id], timeDelta / (1000 * 60 * 60));
+  const backgroundColor = getAgedColour(colours[item.category], timeDelta / (1000 * 60 * 60));
 
   const source = item.sources && item.sources.length && item.sources[0] || item;
 

--- a/src/Edition.js
+++ b/src/Edition.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import GridMap from './GridMap';
 import TreeMap from './TreeMap';
+import TreeMapMixed from './TreeMapMixed';
 import { getNews } from './GoogleNewsRSS';
 
 import Article from './Article';
@@ -111,14 +112,16 @@ class Edition extends Component {
   }
 
   render() {
-    const Map = this.props.mode === "tree" ? TreeMap : GridMap;
+    const Map = {"tree":TreeMap, "grid":GridMap, "tree_mixed":TreeMapMixed}[this.props.mode];
     const { selectedCategories, showImages, colours, itemsPerCategory, newTab } = this.props;
     const { categories } = this.state;
 
     const cats = categories.filter(c => selectedCategories.includes(c.id));
 
+    const newsMix = [];
+
     let items = cats.map(c => {
-      const articles = c.articles.map(a => ({ ...a, weight: weight(a) }));
+      const articles = c.articles.map(a => ({ ...a, weight: weight(a), category: c.id }));
 
       articles.sort((a,b) => b.weight - a.weight)
 
@@ -138,7 +141,6 @@ class Edition extends Component {
     if (items.length === 0) {
       return null;
     }
-
     return (
       <Map
         items={items}

--- a/src/Edition.js
+++ b/src/Edition.js
@@ -118,8 +118,6 @@ class Edition extends Component {
 
     const cats = categories.filter(c => selectedCategories.includes(c.id));
 
-    const newsMix = [];
-
     let items = cats.map(c => {
       const articles = c.articles.map(a => ({ ...a, weight: weight(a), category: c.id }));
 

--- a/src/TreeMapMixed.js
+++ b/src/TreeMapMixed.js
@@ -1,0 +1,167 @@
+import React, { Component } from 'react';
+
+import './TreeMap.css';
+
+/**
+ * @augments Component<{ items: any[], itemRender: (any) => React.ReactNode }>
+ */
+export default class TreeMapMixed extends Component {
+
+  render () {
+    let rootWidth = 768, rootHeight = 1024 - 50;
+    if (this.ref) {
+      rootWidth = this.ref.clientWidth;
+      rootHeight = this.ref.clientHeight;
+    }
+
+    const articleMix = [];
+    this.props.items.forEach(cat => {
+      cat.articles.forEach(a => articleMix.push(a));
+    });
+    articleMix.sort((a,b) => b.weight - a.weight);
+
+    const dimensions = layoutTreeMap([1], { width: rootWidth, height: rootHeight });
+
+    const articleValues = articleMix.map(a => a.weight);
+    const articleDimensions = layoutTreeMap(articleValues, dimensions[0]);
+
+    if (articleMix.length === 0) {
+      return null;
+    }
+
+    return (
+      <ol className="TreeMap-cat-list" ref={r => this.ref = r}>
+        {(
+          <li key={this.props.items[0].key} style={dimensions[0]}>
+            <ol className="TreeMap-article-list">
+              {
+                articleMix.map((article,i) => {
+                  const childProps = {
+                    key: article.category+":"+article.id,
+                    item: article,
+                    category: article.category,
+                    style: {
+                      ...articleDimensions[i],
+                      position: "absolute",
+                    },
+                  };
+
+                  return this.props.itemRender(childProps);
+                })
+              }
+            </ol>
+          </li>
+        )}
+      </ol>
+    );
+  }
+}
+
+/**
+ *
+ * @param {Array<number>} values
+ * @param {{width: number, height: number}} dimensions
+ */
+function layoutTreeMap (values, { width, height }) {
+  const dimensions = [];
+
+  const ratio = height / width;
+  const totalValue = values.reduce(sum, 0);
+
+  let valueWidth = Math.sqrt(totalValue / ratio);
+  let valueHeight = valueWidth * ratio;
+
+  const scale = width / valueWidth;
+
+  let horizontal = width < height;
+  const row = []; // currentRow
+
+  let currentX = 0;
+  let currentY = 0;
+
+  values.forEach(value => {
+    const w = horizontal ? valueWidth : valueHeight; // valueLength
+    const worst_n = worst(row, w);
+    const worst_y = worst([ ...row, value ], w);
+
+    if(worst_y > worst_n){
+      layoutRow(row);
+      row.length = 0;
+    }
+
+    row.push(value);
+  });
+
+  if (row.length) {
+    layoutRow(row);
+  }
+
+  return dimensions;
+
+  function layoutRow (row) {
+    let rowValue = row.reduce(sum, 0);
+    let rowWidth;
+    let rowHeight;
+    let x = currentX;
+    let y = currentY;
+
+    if(!horizontal){
+      rowWidth = rowValue / valueHeight;
+      rowHeight = valueHeight;
+      valueWidth -= rowWidth;
+      currentX += rowWidth;
+    }
+    else {
+      rowWidth = valueWidth;
+      rowHeight = rowValue / valueWidth;
+      valueHeight -= rowHeight;
+      currentY += rowHeight;
+    }
+
+    row.forEach(value => {
+      let valueWidth;
+      let valueHeight;
+
+      if(!horizontal){
+        valueWidth = rowWidth;
+        valueHeight = value / rowWidth;
+      }
+      else {
+        valueWidth = value / rowHeight;
+        valueHeight = rowHeight;
+      }
+
+      dimensions.push({
+        top: y * scale,
+        left: x * scale,
+        width: valueWidth * scale,
+        height: valueHeight * scale,
+      });
+
+      if(!horizontal){
+        y += valueHeight;
+      }
+      else {
+        x += valueWidth;
+      }
+    });
+
+    horizontal = !horizontal;
+  }
+
+  function worst(/* row */ R, /* width */ w) {
+    if(!R.length) return Infinity;
+
+    var w_2 = w*w,
+        s = R.reduce(sum, 0),
+        s_2 = s*s,
+        r_max = R[0],
+        r_min = R[R.length - 1];
+
+    return Math.max(w_2*r_min/s_2, s_2/(w_2*r_max));
+  }
+
+  function sum(a, b) {
+    return a + b;
+  }
+}


### PR DESCRIPTION
As I remember the newsmap.jp didn't group the news by category in the TreeMap view. 
So I created the TreeMapMixed alternative for the user that mixes the categories' articles by their weight.